### PR TITLE
Handle warnings which are plain strings instead of objects.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 function filterWarnings(exclude, result) {
   result.compilation.warnings = result.compilation.warnings.filter( // eslint-disable-line no-param-reassign
-    warning => !exclude.some(regexp => regexp.test(warning.message)),
+    warning => !exclude.some(regexp => regexp.test(warning.message || warning)),
   );
 }
 


### PR DESCRIPTION
Some plugins (e.g. Google Workbox) can push plain strings as warnings
instead of objects with a `message` property.